### PR TITLE
fix: do not crash on cpython 3.11

### DIFF
--- a/milksnake/ffi.py
+++ b/milksnake/ffi.py
@@ -5,7 +5,7 @@ import cffi
 from ._compat import PY2
 
 
-_directive_re = re.compile(r'^\s*#.*?$(?m)')
+_directive_re = re.compile(r'(?m)^\s*#.*?$')
 
 
 def make_ffi(module_path, header, strip_directives=False):


### PR DESCRIPTION
```
  File "/tmp/build-env-dxzj3a1v/lib/python3.11/site-packages/milksnake/setuptools_ext.py", line 226, in make_ffi
    from milksnake.ffi import make_ffi
  File "/tmp/build-env-dxzj3a1v/lib/python3.11/site-packages/milksnake/ffi.py", line 8, in <module>
    _directive_re = re.compile(r'^\s*#.*?$(?m)')
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/__init__.py", line 227, in compile
    return _compile(pattern, flags)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/__init__.py", line 294, in _compile
    p = _compiler.compile(pattern, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/_compiler.py", line 743, in compile
    p = _parser.parse(p, flags)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/_parser.py", line 980, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/_parser.py", line 455, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/korniltsev/.asdf/installs/python/3.11.0/lib/python3.11/re/_parser.py", line 841, in _parse
    raise source.error('global flags not at the start '
re.error: global flags not at the start of the expression at position 9
```

fix crash